### PR TITLE
ci: add timeout settings to all GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -10,6 +10,7 @@ concurrency:
 jobs:
   ui_biome_check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -39,6 +40,7 @@ jobs:
 
   ui_storybook_build_check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -67,6 +69,7 @@ jobs:
 
   web_build_check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -95,6 +98,7 @@ jobs:
 
   web_type_check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -123,6 +127,7 @@ jobs:
 
   ui_tsc_check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -151,6 +156,7 @@ jobs:
 
   packages_tsc_check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -179,6 +185,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -207,6 +214,7 @@ jobs:
 
   notify:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs:
       [
         ui_biome_check,

--- a/.github/workflows/ci-deploy-storybook.yml
+++ b/.github/workflows/ci-deploy-storybook.yml
@@ -20,6 +20,7 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci-vrt-publish.yml
+++ b/.github/workflows/ci-vrt-publish.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   setup-playwright:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -49,6 +50,7 @@ jobs:
   setup:
     needs: setup-playwright
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -106,6 +108,7 @@ jobs:
   vrt_publish:
     needs: setup
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary
- All GitHub Actions workflows now have timeout settings to prevent infinite execution
- Timeout durations are set based on typical execution times for each job type

## Changes
- **ci-check.yml**: Added timeouts to 8 jobs (5-15 minutes)
  - Build jobs: 15 minutes
  - Type check jobs: 10 minutes
  - Test jobs: 10 minutes
  - Notify job: 5 minutes
- **ci-vrt-publish.yml**: Added timeouts to 3 jobs (15-20 minutes)
  - Playwright setup: 15 minutes
  - VRT execution: 20 minutes
  - Publishing: 20 minutes
- **ci-deploy-storybook.yml**: Added timeout to deploy job (20 minutes)

## Benefits
- Prevents workflows from running indefinitely
- Reduces resource consumption
- Provides early failure detection for stuck jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)