### PR TITLE
chore(ui): upgrade Storybook to v10.0.7 and fix VRT artifact merge

### DIFF
--- a/.github/workflows/ci-vrt-publish.yml
+++ b/.github/workflows/ci-vrt-publish.yml
@@ -154,8 +154,19 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: screenshots-*
-          merge-multiple: true
-          path: packages/ui/__screenshots__/
+          merge-multiple: false
+          path: artifacts/
+
+      - name: Merge screenshots safely
+        run: |
+          mkdir -p packages/ui/__screenshots__
+          for shard in artifacts/screenshots-*; do
+            if [ -d "$shard" ]; then
+              echo "Merging $shard..."
+              cp -rn "$shard/packages/ui/__screenshots__/"* packages/ui/__screenshots__/ 2>/dev/null || true
+            fi
+          done
+          echo "Total screenshots: $(find packages/ui/__screenshots__ -name '*.png' | wc -l)"
 
       - name: Publish Reg Suit
         env:


### PR DESCRIPTION
## Summary
- Upgrade Storybook to v10.0.7
- Add Skeleton component (Product001)
- Fix VRT screenshot corruption issue in CI workflow

## Changes

### Storybook Upgrade
- Updated Storybook packages to v10.0.7
- Regenerated screenshots with new Storybook version

### New Component
- Added `Skeleton/Product001` component with variants:
  - Default skeleton loader
  - Custom styling support
  - Configurable dimensions

### CI/CD Fix
- **Fixed**: CRC error in reg-suit caused by artifact merge
- **Changed**: artifact download strategy from `merge-multiple: true` to manual merge
- **Added**: safe merge step using `cp -rn` to prevent file overwrites
- **Added**: logging for screenshot count validation

## Technical Details

The VRT was failing with PNG CRC errors because multiple parallel shards were uploading screenshots simultaneously, and the automatic merge was corrupting files. The fix downloads artifacts separately and merges them manually with the `-n` (no-clobber) flag to prevent overwrites.

## Test plan
- [x] Local screenshot generation works correctly
- [ ] CI workflow completes without CRC errors
- [ ] All 337 screenshots are properly merged
- [ ] reg-suit publishes successfully to S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)