### PR TITLE
Update Button001 default story text

### DIFF
--- a/packages/ui/components/Basic/Button/Product001/index.stories.tsx
+++ b/packages/ui/components/Basic/Button/Product001/index.stories.tsx
@@ -15,7 +15,7 @@ const Template: StoryFn<typeof Button001> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-  children: "test",
+  children: "Button",
   animation: {
     type: "001",
     duration: 0.25,


### PR DESCRIPTION
## Summary
- Changed Button001 default story text from 'test' to 'Button' for better clarity

## Test plan
- [ ] Verify Button001 story displays "Button" text correctly in Storybook
- [ ] Check that visual regression tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)